### PR TITLE
Added utf-8 encoding when reading emojis.json

### DIFF
--- a/fansi/data.py
+++ b/fansi/data.py
@@ -61,7 +61,7 @@ class EmojiCodes:
     """
 
     emojipath = path.join(path.dirname(__file__), "emojis.json")
-    with open(emojipath, "r") as data:
+    with open(emojipath, "r", encoding="utf-8") as data:
         emojis = json.load(data)
 
     @classmethod


### PR DESCRIPTION
While importing using Windows x64, Anaconda Python 3.6: 'from fansi import fansi' I got the following error.
> UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 34: character maps to <undefined>

I had to add: encoding="utf-8" to line:62 in 'data.py' to get it to import correctly.
[with open(emojipath, "r", encoding="utf-8") as data:](url)